### PR TITLE
Fix CSS warnings and override default text-transform on invite codes

### DIFF
--- a/components/FriendCodesPanel.tsx
+++ b/components/FriendCodesPanel.tsx
@@ -32,7 +32,7 @@ function FriendInviteCard({ invite }: { invite: FriendInvite }) {
         <div className="vc-friend-codes-card">
             <Flex justify={Flex.Justify.START}>
                 <div className="vc-friend-codes-card-title">
-                    <Forms.FormTitle tag="h4">
+                    <Forms.FormTitle tag="h4" style={{ textTransform: "none" }}>
                         {invite.code}
                     </Forms.FormTitle>
                     <span>

--- a/components/styles.css
+++ b/components/styles.css
@@ -6,13 +6,17 @@
   border-radius: 5px;
   border-color: var(--background-tertiary);
   background-color: var(--background-secondary);
+}
 
-  .vc-friend-codes-card-title span {
-    color: var(--header-secondary);
-    font-family: var(--font-primary);
-    font-size: 14px;
-    font-weight: 400;
-  } 
+.vc-friend-codes-card-title :first-child {
+  text-transform: none;
+}
+
+.vc-friend-codes-card-title span {
+  color: var(--header-secondary);
+  font-family: var(--font-primary);
+  font-size: 14px;
+  font-weight: 400;
 }
 
 .vc-friend-codes-info-header {

--- a/components/styles.css
+++ b/components/styles.css
@@ -8,10 +8,6 @@
   background-color: var(--background-secondary);
 }
 
-.vc-friend-codes-card-title :first-child {
-  text-transform: none;
-}
-
 .vc-friend-codes-card-title span {
   color: var(--header-secondary);
   font-family: var(--font-primary);


### PR DESCRIPTION
Gets rid of the constant

```
▲ [WARNING] Expected identifier but found "." [css-syntax-error]

    src/thirdpartyplugins/friendCodes/components/styles.css:10:2:
      10 │   .vc-friend-codes-card-title span {
         ╵   ^

1 warning
```

and fixes the casing here as invites are case-sensitive

![Example showing fixed invite code casing](https://github.com/user-attachments/assets/c10f8e8e-1b60-4ffe-9d64-a2da6f13851a)

No this invite does not work anymore.